### PR TITLE
feat(socket): add JWT-authenticated Socket.IO with online presence and real-time messaging

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -27,6 +27,7 @@
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.61.1",
     "react-router-dom": "^7.7.1",
+    "socket.io-client": "^4.8.1",
     "tailwind-merge": "^3.3.1",
     "zod": "^4.0.9",
     "zustand": "^5.0.7"

--- a/apps/client/src/components/ChatWindow.tsx
+++ b/apps/client/src/components/ChatWindow.tsx
@@ -8,8 +8,9 @@ import { useConversationStore } from "@/zustand/useConversationStore";
 import { useGetMessages } from "@/hooks/useGetMessages";
 import { useAuthContext } from "@/context/AuthContext";
 import { usePickFrom } from "@/hooks/z-generic";
-
+import { useConversationRoom } from "@/hooks/useConversationRoom";
 export function ChatWindow() {
+  useConversationRoom();
   const { conversationId } = useParams<{ conversationId: string }>();
 
   const { authUser: me } = useAuthContext();
@@ -30,7 +31,7 @@ export function ChatWindow() {
     if (conversationId && conversationId !== selectedConversationId) {
       setSelectedConversationId(conversationId);
     }
-    // 没有参数（/chats），清空选中，回到欢迎页
+    // remove selectedId and back to welcome message
     if (!conversationId && selectedConversationId !== null) {
       setSelectedConversationId(null);
     }

--- a/apps/client/src/components/ConversationItem.tsx
+++ b/apps/client/src/components/ConversationItem.tsx
@@ -1,12 +1,14 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { useSocketContext } from "@/context/SocketContext";
 import { useConversationStore } from "@/zustand/useConversationStore";
-import { useNavigate } from "react-router-dom";
 
+import { cn } from "@/lib/utils";
+import { useNavigate } from "react-router-dom";
 type ConversationProps = {
   id: string;
   receiverId: string;
   avatarUrl: string;
-  nikename: string;
+  nickname: string;
   lastMessage: string;
 };
 
@@ -14,7 +16,7 @@ const Conversation = ({
   id,
   receiverId,
   avatarUrl,
-  nikename,
+  nickname,
   lastMessage,
 }: ConversationProps) => {
   const navigate = useNavigate();
@@ -22,6 +24,9 @@ const Conversation = ({
   const { setSelectedConversationId, setReceiverId } =
     useConversationStore.getState();
 
+  const isOnline = useSocketContext().onlineUsers.includes(receiverId);
+  console.log(receiverId);
+  console.log("useSocketContext().onlineUsers", useSocketContext().onlineUsers);
   const handleOnClick = () => {
     setSelectedConversationId(id);
     setReceiverId(receiverId);
@@ -30,6 +35,21 @@ const Conversation = ({
     console.log("receiverId", receiverId);
   };
 
+  function PresenceBadge({ online }: { online: boolean }) {
+    return (
+      <span
+        className={cn(
+          "absolute bottom-0 right-0 translate-x-1/4 translate-y-1/4",
+          "h-3.5 w-3.5 rounded-full ring-2 ring-background",
+          online
+            ? "bg-gradient-to-br from-emerald-400 to-emerald-600 shadow-[0_0_0_2px_rgba(16,185,129,0.25)]"
+            : "bg-zinc-400/80"
+        )}
+        aria-label={online ? "online" : "offline"}
+      />
+    );
+  }
+
   return (
     <>
       <div
@@ -37,15 +57,19 @@ const Conversation = ({
         onClick={handleOnClick}
       >
         {/* avatar */}
-        <Avatar className="w-12 h-12">
-          <AvatarImage src={avatarUrl} />
-          <AvatarFallback>{nikename.substring(0, 2)}</AvatarFallback>
-        </Avatar>
+        <div className="relative">
+          <Avatar className="w-12 h-12">
+            <AvatarImage src={avatarUrl} />
+            <AvatarFallback>{nickname.substring(0, 2)}</AvatarFallback>
+          </Avatar>
+
+          <PresenceBadge online={isOnline} />
+        </div>
 
         {/* min-w-0 allows the flebox to shrink, default is auto*/}
         <div className="flex flex-col flex-1 min-w-0">
           <div className="flex justify-between items-center">
-            <p className="font-bold">{nikename}</p>
+            <p className="font-bold">{nickname}</p>
             {/* TODO: Maybe add timestramp */}
           </div>
           <p className="text-sm text-muted-foreground truncate">

--- a/apps/client/src/components/ConversationSidebar.tsx
+++ b/apps/client/src/components/ConversationSidebar.tsx
@@ -73,7 +73,7 @@ function ConversationSidebar() {
                 id={item.id}
                 receiverId={receiverId}
                 avatarUrl={avatarUrl}
-                nikename={displayName}
+                nickname={displayName}
                 lastMessage={lastMessage}
               ></Conversation>
             );

--- a/apps/client/src/context/SocketContext.tsx
+++ b/apps/client/src/context/SocketContext.tsx
@@ -1,0 +1,71 @@
+import {
+  createContext,
+  useState,
+  useEffect,
+  useContext,
+  type ReactNode,
+  useRef,
+} from "react";
+import { useAuthContext } from "./AuthContext";
+import io, { Socket } from "socket.io-client";
+
+interface ISocketContext {
+  socket: Socket | null;
+  onlineUsers: string[];
+}
+const SocketContext = createContext<ISocketContext | undefined>(undefined);
+
+const socketURL = import.meta.env.DEV ? "http://localhost:3001" : "/";
+
+export const SocketContextProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const socketRef = useRef<Socket | null>(null);
+  const [onlineUsers, setOnlineUsers] = useState<string[]>([]);
+  const { authUser, isLoading } = useAuthContext();
+  useEffect(() => {
+    if (isLoading || !authUser) return;
+
+    if (authUser && !isLoading) {
+      const socket = io(socketURL, {
+        transports: ["websocket", "polling"],
+        withCredentials: true,
+      });
+      socketRef.current = socket;
+      socket.on("onlineUsers", (users: string[]) => {
+        setOnlineUsers(users);
+      });
+      socket.on("connect_error", (e) =>
+        console.error("connect_error:", e.message)
+      );
+
+      return () => {
+        socket.close();
+        socketRef.current = null;
+      };
+    } else if (!authUser && !isLoading) {
+      if (socketRef.current) {
+        socketRef.current.disconnect();
+        socketRef.current = null;
+      }
+    }
+  }, [authUser, isLoading]);
+
+  return (
+    <SocketContext.Provider value={{ socket: socketRef.current, onlineUsers }}>
+      {children}
+    </SocketContext.Provider>
+  );
+};
+
+export const useSocketContext = (): ISocketContext => {
+  const context = useContext(SocketContext);
+  if (context === undefined) {
+    throw new Error(
+      "useSocketContext must be used within SocketContextProvider"
+    );
+  }
+  return context;
+};

--- a/apps/client/src/hooks/useAddMessageToConversation.tsx
+++ b/apps/client/src/hooks/useAddMessageToConversation.tsx
@@ -34,10 +34,14 @@ export function useAddMessageToConversation() {
           { signal: ctrl.signal }
         );
 
-        // 追加到当前会话消息列表
+        // add to current message
         const prev =
           useConversationStore.getState().messages[conversationId] ?? [];
-        setMessages(conversationId, [...prev, data]);
+
+        // remove duplicate
+        if (!prev.some((m) => m.id === data.id)) {
+          setMessages(conversationId, [...prev, data]);
+        }
 
         return data;
       } catch (err: any) {

--- a/apps/client/src/hooks/useConversationRoom.tsx
+++ b/apps/client/src/hooks/useConversationRoom.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import { useSocketContext } from "@/context/SocketContext";
+import { usePickFrom } from "@/hooks/z-generic";
+import { useConversationStore } from "@/zustand/useConversationStore";
+
+export function useConversationRoom() {
+  const { socket } = useSocketContext();
+  const { selectedConversationId } = usePickFrom(
+    useConversationStore,
+    "selectedConversationId"
+  );
+
+  useEffect(() => {
+    if (!socket || !selectedConversationId) return;
+
+    socket.emit(
+      "conversation:join",
+      { conversationId: selectedConversationId },
+      (ack?: {
+        ok: boolean;
+        conversationId?: string;
+        size?: number;
+        reason?: string;
+      }) => {
+        console.log("[client] join ack:", ack);
+      }
+    );
+    return () => {
+      socket.emit("conversation:leave", {
+        conversationId: selectedConversationId,
+      });
+    };
+  }, [socket, selectedConversationId]);
+}

--- a/apps/client/src/hooks/useListenMessages.tsx
+++ b/apps/client/src/hooks/useListenMessages.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import { useSocketContext } from "@/context/SocketContext";
+import { useConversationStore } from "@/zustand/useConversationStore";
+import { type MessageType } from "@chat-app/validators";
+import { useAuthContext } from "@/context/AuthContext";
+export const useListenMessages = () => {
+  const { socket } = useSocketContext();
+  const { authUser } = useAuthContext();
+  useEffect(() => {
+    if (!socket) return;
+
+    const onNew = ({ message }: { message: MessageType }) => {
+      if (!message?.id || !message?.conversationId) return;
+      const cid = message.conversationId;
+
+      // avoid duplicated message
+      if (message.sender?.id === authUser?.id) return;
+      // use the newest state
+      const { messages, setMessages } = useConversationStore.getState();
+      const prev = messages[cid] ?? [];
+
+      if (prev.some((m) => m.id === message.id)) return; // double check de-dup
+      setMessages(cid, [...prev, message]);
+    };
+
+    socket.on("message:new", onNew);
+    return () => {
+      socket.off("message:new", onNew); // cleanup 返回 void
+    };
+  }, [socket]);
+};

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -4,12 +4,14 @@ import "./index.css";
 import App from "./App.tsx";
 import { BrowserRouter } from "react-router-dom";
 import { AuthContextProvider } from "./context/AuthContext.tsx";
-
+import { SocketContextProvider } from "./context/SocketContext.tsx";
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>
       <AuthContextProvider>
-        <App />
+        <SocketContextProvider>
+          <App />
+        </SocketContextProvider>
       </AuthContextProvider>
     </BrowserRouter>
   </StrictMode>

--- a/apps/client/src/pages/HomePage.tsx
+++ b/apps/client/src/pages/HomePage.tsx
@@ -1,6 +1,8 @@
 import { ActionSidebar } from "@/components/ActionSidebar";
+import { useListenMessages } from "@/hooks/useListenMessages";
 import { Outlet } from "react-router-dom";
 function HomePage() {
+  useListenMessages();
   return (
     <div className="flex h-screen w-screen p-4 gap-4">
       {/* flex-shrink-0 no shrink */}

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -18,12 +18,14 @@
     "@prisma/client": "^6.10.1",
     "@types/express-serve-static-core": "^5.0.7",
     "bcryptjs": "^3.0.2",
+    "cookie": "^1.0.2",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.6.1",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "prisma": "^6.10.1",
+    "socket.io": "^4.8.1",
     "zod": "^4.0.5"
   },
   "devDependencies": {

--- a/apps/server/src/db/prisma.ts
+++ b/apps/server/src/db/prisma.ts
@@ -9,10 +9,10 @@ const prisma = new PrismaClient({
   ],
 });
 
-prisma.$on("query", (e) => {
-  console.log(`[Prisma Query] ${e.query}`);
-  console.log(`[Prisma Params] ${e.params}`);
-  console.log(`[Prisma Duration] ${e.duration}ms`);
-});
+// prisma.$on("query", (e) => {
+//   console.log(`[Prisma Query] ${e.query}`);
+//   console.log(`[Prisma Params] ${e.params}`);
+//   console.log(`[Prisma Duration] ${e.duration}ms`);
+// });
 
 export default prisma;

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -4,8 +4,7 @@ import messageRoutes from "./routes/message.route.js";
 import cookieParser from "cookie-parser";
 import { config } from "./config.js";
 import usersRoutes from "./routes/users.route.js";
-const app = express();
-
+import { app, server } from "./socket/socket.js";
 const PORT = 3001;
 
 // parsing json
@@ -15,6 +14,6 @@ app.use("/api/auth", authRoutes);
 app.use("/api/messages", messageRoutes);
 app.use("/api/users", usersRoutes);
 
-app.listen(PORT, () => {
-  console.log(`😊😊Server is running at http://localhost:${PORT}/`);
+server.listen(PORT, () => {
+  console.log(`😊😊Server is running at http://localhost:${PORT}`);
 });

--- a/apps/server/src/socket/socket.ts
+++ b/apps/server/src/socket/socket.ts
@@ -1,0 +1,142 @@
+import { Server } from "socket.io";
+import http from "http";
+import express from "express";
+import jwt from "jsonwebtoken";
+import cookie from "cookie";
+import prisma from "../db/prisma.js";
+// JWT-authenticate and attach userId
+type JwtPayload = { userId: string; iat: number; exp: number };
+
+const app = express();
+
+const server = http.createServer(app);
+
+const io = new Server(server, {
+  cors: {
+    origin: ["http://localhost:5173"],
+    methods: "GET,HEAD,PUT,PATCH,POST,DELETE",
+    credentials: true,
+  },
+});
+
+io.use((socket, next) => {
+  try {
+    const raw = socket.handshake.headers.cookie ?? "";
+    console.log("[socket] Cookie hdr:", raw); //jwt
+
+    const { myJWT } = cookie.parse(raw);
+    if (!myJWT) return next(new Error("unauthorized")); // no jwt
+
+    const { userId } = jwt.verify(myJWT, process.env.JWT_SECRET!) as JwtPayload;
+    (socket.data as any).userId = userId; // attach
+    return next();
+  } catch (e) {
+    console.error("[socket] JWT verify failed:", e);
+    return next(new Error("unauthorized"));
+  }
+});
+
+// one userId has many socket.id
+const online = new Map<string, Set<string>>();
+const broadcastOnline = () => io.emit("onlineUsers", [...online.keys()]);
+
+// step1: user connection established, update userSocketMap
+io.on("connection", (socket) => {
+  // identity: attach JWT to socket.data）
+  const userId = (socket.data as any).userId as string | undefined;
+  console.log("[socket] connected:", { sid: socket.id, userId });
+
+  if (!userId) {
+    console.warn("[socket] no userId on socket.data, disconnect");
+    socket.disconnect();
+    return;
+  }
+
+  // presence：多标签/多设备
+  let set = online.get(userId);
+  if (!set) online.set(userId, (set = new Set()));
+  set.add(socket.id);
+
+  // user private room
+  socket.join(`user:${userId}`);
+
+  broadcastOnline();
+
+  // tool
+  const roomSize = (conversationId: string) =>
+    io.sockets.adapter.rooms.get(`conversation:${conversationId}`)?.size ?? 0;
+
+  // ---- conversation rooms ----
+  socket.on(
+    "conversation:join",
+    async (
+      { conversationId }: { conversationId: string },
+      ack?: (res: {
+        ok: boolean;
+        conversationId?: string;
+        size?: number;
+        reason?: string;
+      }) => void
+    ) => {
+      if (!conversationId) {
+        ack?.({ ok: false, reason: "no_conversationId" });
+        return;
+      }
+
+      // （可选 authZ）建议在这里用 Prisma 校验 membership
+      const member = prisma.conversationParticipant.findUnique({
+        where: { conversationId_userId: { conversationId, userId } },
+      });
+      if (!member) {
+        ack?.({ ok: false, reason: "not_member" });
+        return;
+      }
+
+      const prev = (socket.data as any).activeConvId as string | undefined;
+      if (prev && prev !== conversationId) {
+        socket.leave(`conversation:${prev}`);
+        console.log("[socket] auto-leave prev:", { sid: socket.id, prev });
+      }
+
+      socket.join(`conversation:${conversationId}`);
+      (socket.data as any).activeConvId = conversationId;
+
+      const size = roomSize(conversationId);
+      console.log("[socket] join:", {
+        sid: socket.id,
+        conversationId,
+        size,
+        rooms: [...socket.rooms],
+      });
+      ack?.({ ok: true, conversationId, size });
+    }
+  );
+
+  socket.on(
+    "conversation:leave",
+    ({ conversationId }: { conversationId: string }) => {
+      if (!conversationId) return;
+      socket.leave(`conversation:${conversationId}`);
+
+      // 清掉活动会话标记
+      const prev = (socket.data as any).activeConvId as string | undefined;
+      if (prev === conversationId)
+        (socket.data as any).activeConvId = undefined;
+
+      const size = roomSize(conversationId);
+      console.log("[socket] leave:", { sid: socket.id, conversationId, size });
+    }
+  );
+
+  socket.on("disconnect", () => {
+    const set = online.get(userId);
+    if (set) {
+      set.delete(socket.id);
+      if (set.size === 0) online.delete(userId);
+    }
+    broadcastOnline();
+    console.log("[socket] disconnected:", { sid: socket.id, userId });
+  });
+});
+
+export { app, io, server };

--- a/packages/validators/index.ts
+++ b/packages/validators/index.ts
@@ -16,6 +16,7 @@ const lastMessageSelect = {
   id: true,
   content: true,
   createdAt: true,
+  conversationId: true,
   sender: {
     select: { id: true, username: true, nickname: true, profilePic: true },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       react-router-dom:
         specifier: ^7.7.1
         version: 7.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      socket.io-client:
+        specifier: ^4.8.1
+        version: 4.8.1
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -147,6 +150,9 @@ importers:
       bcryptjs:
         specifier: ^3.0.2
         version: 3.0.2
+      cookie:
+        specifier: ^1.0.2
+        version: 1.0.2
       cookie-parser:
         specifier: ^1.4.7
         version: 1.4.7
@@ -165,6 +171,9 @@ importers:
       prisma:
         specifier: ^6.10.1
         version: 6.12.0(typescript@5.8.3)
+      socket.io:
+        specifier: ^4.8.1
+        version: 4.8.1
       zod:
         specifier: ^4.0.5
         version: 4.0.9
@@ -1049,6 +1058,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
@@ -1292,6 +1304,10 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -1343,6 +1359,10 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base64id@2.0.0:
+    resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
+    engines: {node: ^4.5.0 || >= 5.9}
 
   bcryptjs@3.0.2:
     resolution: {integrity: sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==}
@@ -1482,6 +1502,15 @@ packages:
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
+  debug@4.3.7:
+    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
     engines: {node: '>=6.0'}
@@ -1536,6 +1565,17 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  engine.io-client@6.6.3:
+    resolution: {integrity: sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==}
+
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
+
+  engine.io@6.6.4:
+    resolution: {integrity: sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==}
+    engines: {node: '>=10.2.0'}
 
   enhanced-resolve@5.18.2:
     resolution: {integrity: sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==}
@@ -2065,6 +2105,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
@@ -2353,6 +2397,21 @@ packages:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
 
+  socket.io-adapter@2.5.5:
+    resolution: {integrity: sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==}
+
+  socket.io-client@4.8.1:
+    resolution: {integrity: sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io-parser@4.2.4:
+    resolution: {integrity: sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io@4.8.1:
+    resolution: {integrity: sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==}
+    engines: {node: '>=10.2.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2580,6 +2639,22 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.17.1:
+    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -3335,6 +3410,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.45.1':
     optional: true
 
+  '@socket.io/component-emitter@3.1.2': {}
+
   '@standard-schema/utils@0.3.0': {}
 
   '@tailwindcss/node@4.1.11':
@@ -3614,6 +3691,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.1
@@ -3666,6 +3748,8 @@ snapshots:
       - debug
 
   balanced-match@1.0.2: {}
+
+  base64id@2.0.0: {}
 
   bcryptjs@3.0.2: {}
 
@@ -3814,6 +3898,10 @@ snapshots:
 
   date-fns@4.1.0: {}
 
+  debug@4.3.7:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.1(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
@@ -3851,6 +3939,36 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   encodeurl@2.0.0: {}
+
+  engine.io-client@6.6.3:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.3.7
+      engine.io-parser: 5.2.3
+      ws: 8.17.1
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  engine.io-parser@5.2.3: {}
+
+  engine.io@6.6.4:
+    dependencies:
+      '@types/cors': 2.8.19
+      '@types/node': 24.1.0
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cookie: 0.7.2
+      cors: 2.8.5
+      debug: 4.3.7
+      engine.io-parser: 5.2.3
+      ws: 8.17.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   enhanced-resolve@5.18.2:
     dependencies:
@@ -4378,6 +4496,8 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@0.6.3: {}
+
   negotiator@1.0.0: {}
 
   node-releases@2.0.19: {}
@@ -4676,6 +4796,47 @@ snapshots:
     dependencies:
       semver: 7.7.2
 
+  socket.io-adapter@2.5.5:
+    dependencies:
+      debug: 4.3.7
+      ws: 8.17.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-client@4.8.1:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.3.7
+      engine.io-client: 6.6.3
+      socket.io-parser: 4.2.4
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.4:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.3.7
+    transitivePeerDependencies:
+      - supports-color
+
+  socket.io@4.8.1:
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.5
+      debug: 4.3.7
+      engine.io: 6.6.4
+      socket.io-adapter: 2.5.5
+      socket.io-parser: 4.2.4
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   source-map-js@1.2.1: {}
 
   statuses@2.0.1: {}
@@ -4859,6 +5020,10 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  ws@8.17.1: {}
+
+  xmlhttprequest-ssl@2.1.2: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
**Summary**
Introduce Socket.IO with JWT handshake, online presence, and room-based real-time messaging. Client now joins per-conversation rooms and receives message:new events without refresh.

**Server**
**Auth (authN)**: Verify JWT from HttpOnly cookie in Socket.IO handshake; attach `socket.data.userId`.
**Presence**: online: `Map<userId, Set<socketId>>`; broadcast onlineUsers on connect/disconnect.
**Rooms**: Track `socket.data.activeConvId`; auto-leave previous room on switch.

**Client**
**SocketContext**: provide `{ socket, onlineUsers }`; connect with `transports: ["websocket"]`
**Global listener**: `useListenMessages()` mounted in `HomePage` to handle `message:new` and de-dup by id
**Room hook**: `useConversationRoom()` in ChatWindow emits `conversation:join/leave` on selection change; re-join on reconnect.
**Double-write guard**: Listener de-dups; sender path also de-dups on HTTP return.
